### PR TITLE
chore: reflect latest mitum-currency; replace module paths

### DIFF
--- a/cmds/flags.go
+++ b/cmds/flags.go
@@ -11,12 +11,11 @@ import (
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util/encoder"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 )
 
 type KeyFlag struct {
-	Key currency.BaseAccountKey
+	Key currencybase.BaseAccountKey
 }
 
 func (v *KeyFlag) UnmarshalText(b []byte) error {
@@ -47,7 +46,7 @@ func (v *KeyFlag) UnmarshalText(b []byte) error {
 		weight = uint(i)
 	}
 
-	if k, err := currency.NewBaseAccountKey(pk, weight); err != nil {
+	if k, err := currencybase.NewBaseAccountKey(pk, weight); err != nil {
 		return err
 	} else if err := k.IsValid(nil); err != nil {
 		return errors.Wrap(err, "invalid key string")
@@ -149,11 +148,11 @@ func (v *AddressFlag) Encode(enc encoder.Encoder) (base.Address, error) {
 }
 
 type BigFlag struct {
-	currency.Big
+	currencybase.Big
 }
 
 func (v *BigFlag) UnmarshalText(b []byte) error {
-	if a, err := currency.NewBigFromString(string(b)); err != nil {
+	if a, err := currencybase.NewBigFromString(string(b)); err != nil {
 		return errors.Wrapf(err, "invalid big string, %q", string(b))
 	} else if err := a.IsValid(nil); err != nil {
 		return err
@@ -165,11 +164,11 @@ func (v *BigFlag) UnmarshalText(b []byte) error {
 }
 
 type CurrencyIDFlag struct {
-	CID currency.CurrencyID
+	CID currencybase.CurrencyID
 }
 
 func (v *CurrencyIDFlag) UnmarshalText(b []byte) error {
-	cid := currency.CurrencyID(string(b))
+	cid := currencybase.CurrencyID(string(b))
 	if err := cid.IsValid(nil); err != nil {
 		return err
 	}
@@ -183,11 +182,11 @@ func (v *CurrencyIDFlag) String() string {
 }
 
 type ContractIDFlag struct {
-	ID extensioncurrency.ContractID
+	ID currencybase.ContractID
 }
 
 func (v *ContractIDFlag) UnmarshalText(b []byte) error {
-	id := extensioncurrency.ContractID(string(b))
+	id := currencybase.ContractID(string(b))
 	if err := id.IsValid(nil); err != nil {
 		return err
 	}
@@ -201,8 +200,8 @@ func (v *ContractIDFlag) String() string {
 }
 
 type CurrencyAmountFlag struct {
-	CID currency.CurrencyID
-	Big currency.Big
+	CID currencybase.CurrencyID
+	Big currencybase.Big
 }
 
 func (v *CurrencyAmountFlag) UnmarshalText(b []byte) error {
@@ -213,13 +212,13 @@ func (v *CurrencyAmountFlag) UnmarshalText(b []byte) error {
 
 	a, c := l[0], l[1]
 
-	cid := currency.CurrencyID(a)
+	cid := currencybase.CurrencyID(a)
 	if err := cid.IsValid(nil); err != nil {
 		return err
 	}
 	v.CID = cid
 
-	if a, err := currency.NewBigFromString(c); err != nil {
+	if a, err := currencybase.NewBigFromString(c); err != nil {
 		return errors.Wrapf(err, "invalid big string, %q", string(b))
 	} else if err := a.IsValid(nil); err != nil {
 		return err

--- a/cmds/hinters.go
+++ b/cmds/hinters.go
@@ -2,11 +2,14 @@ package cmds
 
 import (
 	"github.com/ProtoconNet/mitum-credential/credential"
-	"github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency-extension/v2/digest"
-	mitumcurrency "github.com/ProtoconNet/mitum-currency/v2/currency"
-	digestisaac "github.com/ProtoconNet/mitum-currency/v2/digest/isaac"
-	isaacoperation "github.com/ProtoconNet/mitum-currency/v2/isaac"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
+	"github.com/ProtoconNet/mitum-currency/v3/digest"
+	digestisaac "github.com/ProtoconNet/mitum-currency/v3/digest/isaac"
+	mitumcurrency "github.com/ProtoconNet/mitum-currency/v3/operation/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/operation/extension"
+	isaacoperation "github.com/ProtoconNet/mitum-currency/v3/operation/isaac"
+	currencystate "github.com/ProtoconNet/mitum-currency/v3/state/currency"
+	extensionstate "github.com/ProtoconNet/mitum-currency/v3/state/extension"
 	"github.com/ProtoconNet/mitum2/launch"
 	"github.com/ProtoconNet/mitum2/util/encoder"
 	"github.com/pkg/errors"
@@ -17,13 +20,13 @@ var SupportedProposalOperationFactHinters []encoder.DecodeDetail
 
 var hinters = []encoder.DecodeDetail{
 	// revive:disable-next-line:line-length-limit
-	{Hint: mitumcurrency.BaseStateHint, Instance: mitumcurrency.BaseState{}},
-	{Hint: mitumcurrency.NodeHint, Instance: mitumcurrency.BaseNode{}},
-	{Hint: mitumcurrency.AccountHint, Instance: mitumcurrency.Account{}},
-	{Hint: mitumcurrency.AddressHint, Instance: mitumcurrency.Address{}},
-	{Hint: mitumcurrency.AmountHint, Instance: mitumcurrency.Amount{}},
-	{Hint: mitumcurrency.AccountKeysHint, Instance: mitumcurrency.BaseAccountKeys{}},
-	{Hint: mitumcurrency.AccountKeyHint, Instance: mitumcurrency.BaseAccountKey{}},
+	{Hint: currencybase.BaseStateHint, Instance: currencybase.BaseState{}},
+	{Hint: currencybase.NodeHint, Instance: currencybase.BaseNode{}},
+	{Hint: currencybase.AccountHint, Instance: currencybase.Account{}},
+	{Hint: currencybase.AddressHint, Instance: currencybase.Address{}},
+	{Hint: currencybase.AmountHint, Instance: currencybase.Amount{}},
+	{Hint: currencybase.AccountKeysHint, Instance: currencybase.BaseAccountKeys{}},
+	{Hint: currencybase.AccountKeyHint, Instance: currencybase.BaseAccountKey{}},
 	{Hint: mitumcurrency.CreateAccountsItemMultiAmountsHint, Instance: mitumcurrency.CreateAccountsItemMultiAmounts{}},
 	{Hint: mitumcurrency.CreateAccountsItemSingleAmountHint, Instance: mitumcurrency.CreateAccountsItemSingleAmount{}},
 	{Hint: mitumcurrency.CreateAccountsHint, Instance: mitumcurrency.CreateAccounts{}},
@@ -32,27 +35,27 @@ var hinters = []encoder.DecodeDetail{
 	{Hint: mitumcurrency.TransfersItemSingleAmountHint, Instance: mitumcurrency.TransfersItemSingleAmount{}},
 	{Hint: mitumcurrency.TransfersHint, Instance: mitumcurrency.Transfers{}},
 	{Hint: mitumcurrency.SuffrageInflationHint, Instance: mitumcurrency.SuffrageInflation{}},
-	{Hint: mitumcurrency.AccountStateValueHint, Instance: mitumcurrency.AccountStateValue{}},
-	{Hint: mitumcurrency.BalanceStateValueHint, Instance: mitumcurrency.BalanceStateValue{}},
+	{Hint: currencystate.AccountStateValueHint, Instance: currencystate.AccountStateValue{}},
+	{Hint: currencystate.BalanceStateValueHint, Instance: currencystate.BalanceStateValue{}},
 
-	{Hint: currency.CurrencyDesignHint, Instance: currency.CurrencyDesign{}},
-	{Hint: currency.CurrencyPolicyHint, Instance: currency.CurrencyPolicy{}},
-	{Hint: currency.CurrencyRegisterHint, Instance: currency.CurrencyRegister{}},
-	{Hint: currency.CurrencyPolicyUpdaterHint, Instance: currency.CurrencyPolicyUpdater{}},
-	{Hint: currency.ContractAccountKeysHint, Instance: currency.ContractAccountKeys{}},
-	{Hint: currency.CreateContractAccountsItemMultiAmountsHint, Instance: currency.CreateContractAccountsItemMultiAmounts{}},
-	{Hint: currency.CreateContractAccountsItemSingleAmountHint, Instance: currency.CreateContractAccountsItemSingleAmount{}},
-	{Hint: currency.CreateContractAccountsHint, Instance: currency.CreateContractAccounts{}},
-	{Hint: currency.WithdrawsItemMultiAmountsHint, Instance: currency.WithdrawsItemMultiAmounts{}},
-	{Hint: currency.WithdrawsItemSingleAmountHint, Instance: currency.WithdrawsItemSingleAmount{}},
-	{Hint: currency.WithdrawsHint, Instance: currency.Withdraws{}},
-	{Hint: currency.GenesisCurrenciesFactHint, Instance: currency.GenesisCurrenciesFact{}},
-	{Hint: currency.GenesisCurrenciesHint, Instance: currency.GenesisCurrencies{}},
-	{Hint: currency.NilFeeerHint, Instance: currency.NilFeeer{}},
-	{Hint: currency.FixedFeeerHint, Instance: currency.FixedFeeer{}},
-	{Hint: currency.RatioFeeerHint, Instance: currency.RatioFeeer{}},
-	{Hint: currency.ContractAccountStateValueHint, Instance: currency.ContractAccountStateValue{}},
-	{Hint: currency.CurrencyDesignStateValueHint, Instance: currency.CurrencyDesignStateValue{}},
+	{Hint: currencybase.CurrencyDesignHint, Instance: currencybase.CurrencyDesign{}},
+	{Hint: currencybase.CurrencyPolicyHint, Instance: currencybase.CurrencyPolicy{}},
+	{Hint: mitumcurrency.CurrencyRegisterHint, Instance: mitumcurrency.CurrencyRegister{}},
+	{Hint: mitumcurrency.CurrencyPolicyUpdaterHint, Instance: mitumcurrency.CurrencyPolicyUpdater{}},
+	{Hint: currencybase.ContractAccountKeysHint, Instance: currencybase.ContractAccountKeys{}},
+	{Hint: extensioncurrency.CreateContractAccountsItemMultiAmountsHint, Instance: extensioncurrency.CreateContractAccountsItemMultiAmounts{}},
+	{Hint: extensioncurrency.CreateContractAccountsItemSingleAmountHint, Instance: extensioncurrency.CreateContractAccountsItemSingleAmount{}},
+	{Hint: extensioncurrency.CreateContractAccountsHint, Instance: extensioncurrency.CreateContractAccounts{}},
+	{Hint: extensioncurrency.WithdrawsItemMultiAmountsHint, Instance: extensioncurrency.WithdrawsItemMultiAmounts{}},
+	{Hint: extensioncurrency.WithdrawsItemSingleAmountHint, Instance: extensioncurrency.WithdrawsItemSingleAmount{}},
+	{Hint: extensioncurrency.WithdrawsHint, Instance: extensioncurrency.Withdraws{}},
+	{Hint: mitumcurrency.GenesisCurrenciesFactHint, Instance: mitumcurrency.GenesisCurrenciesFact{}},
+	{Hint: mitumcurrency.GenesisCurrenciesHint, Instance: mitumcurrency.GenesisCurrencies{}},
+	{Hint: currencybase.NilFeeerHint, Instance: currencybase.NilFeeer{}},
+	{Hint: currencybase.FixedFeeerHint, Instance: currencybase.FixedFeeer{}},
+	{Hint: currencybase.RatioFeeerHint, Instance: currencybase.RatioFeeer{}},
+	{Hint: extensionstate.ContractAccountStateValueHint, Instance: extensionstate.ContractAccountStateValue{}},
+	{Hint: currencystate.CurrencyDesignStateValueHint, Instance: currencystate.CurrencyDesignStateValue{}},
 
 	{Hint: credential.DesignHint, Instance: credential.Design{}},
 	{Hint: credential.DesignStateValueHint, Instance: credential.DesignStateValue{}},
@@ -90,10 +93,10 @@ var supportedProposalOperationFactHinters = []encoder.DecodeDetail{
 	{Hint: mitumcurrency.TransfersFactHint, Instance: mitumcurrency.TransfersFact{}},
 	{Hint: mitumcurrency.SuffrageInflationFactHint, Instance: mitumcurrency.SuffrageInflationFact{}},
 
-	{Hint: currency.CurrencyRegisterFactHint, Instance: currency.CurrencyRegisterFact{}},
-	{Hint: currency.CurrencyPolicyUpdaterFactHint, Instance: currency.CurrencyPolicyUpdaterFact{}},
-	{Hint: currency.CreateContractAccountsFactHint, Instance: currency.CreateContractAccountsFact{}},
-	{Hint: currency.WithdrawsFactHint, Instance: currency.WithdrawsFact{}},
+	{Hint: mitumcurrency.CurrencyRegisterFactHint, Instance: mitumcurrency.CurrencyRegisterFact{}},
+	{Hint: mitumcurrency.CurrencyPolicyUpdaterFactHint, Instance: mitumcurrency.CurrencyPolicyUpdaterFact{}},
+	{Hint: extensioncurrency.CreateContractAccountsFactHint, Instance: extensioncurrency.CreateContractAccountsFact{}},
+	{Hint: extensioncurrency.WithdrawsFactHint, Instance: extensioncurrency.WithdrawsFact{}},
 
 	{Hint: credential.CreateCredentialServiceFactHint, Instance: credential.CreateCredentialServiceFact{}},
 	{Hint: credential.AddTemplateFactHint, Instance: credential.AddTemplateFact{}},

--- a/cmds/operation.go
+++ b/cmds/operation.go
@@ -1,26 +1,25 @@
 package cmds
 
 import (
-	extensioncurrencycmds "github.com/ProtoconNet/mitum-currency-extension/v2/cmds"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
 )
 
 type OperationCommand struct {
-	CreateAccount           currencycmds.CreateAccountCommand                  `cmd:"" name:"create-account" help:"create new account"`
-	KeyUpdater              currencycmds.KeyUpdaterCommand                     `cmd:"" name:"key-updater" help:"update account keys"`
-	Transfer                currencycmds.TransferCommand                       `cmd:"" name:"transfer" help:"transfer amounts to receiver"`
-	CreateContractAccount   extensioncurrencycmds.CreateContractAccountCommand `cmd:"" name:"create-contract-account" help:"create new contract account"`
-	Withdraw                extensioncurrencycmds.WithdrawCommand              `cmd:"" name:"withdraw" help:"withdraw amounts from target contract account"`
-	CreateCredentialService CreateCredentialServiceCommand                     `cmd:"" name:"create-credential-service" help:"register credential service to contract account"`
-	AddTemplate             AddTemplateCommand                                 `cmd:"" name:"add-template" help:"add template to credential service"`
-	AssignCredentials       AssignCredentialsCommand                           `cmd:"" name:"assign-credential" help:"assign credential"`
-	RevokeCredentials       RevokeCredentialsCommand                           `cmd:"" name:"revoke-credential" help:"revoke credential"`
-	CurrencyRegister        currencycmds.CurrencyRegisterCommand               `cmd:"" name:"currency-register" help:"register new currency"`
-	CurrencyPolicyUpdater   currencycmds.CurrencyPolicyUpdaterCommand          `cmd:"" name:"currency-policy-updater" help:"update currency policy"`
-	SuffrageInflation       currencycmds.SuffrageInflationCommand              `cmd:"" name:"suffrage-inflation" help:"suffrage inflation operation"`
-	SuffrageCandidate       currencycmds.SuffrageCandidateCommand              `cmd:"" name:"suffrage-candidate" help:"suffrage candidate operation"`
-	SuffrageJoin            currencycmds.SuffrageJoinCommand                   `cmd:"" name:"suffrage-join" help:"suffrage join operation"`
-	SuffrageDisjoin         currencycmds.SuffrageDisjoinCommand                `cmd:"" name:"suffrage-disjoin" help:"suffrage disjoin operation"` // revive:disable-line:line-length-limit
+	CreateAccount           currencycmds.CreateAccountCommand         `cmd:"" name:"create-account" help:"create new account"`
+	KeyUpdater              currencycmds.KeyUpdaterCommand            `cmd:"" name:"key-updater" help:"update account keys"`
+	Transfer                currencycmds.TransferCommand              `cmd:"" name:"transfer" help:"transfer amounts to receiver"`
+	CreateContractAccount   currencycmds.CreateContractAccountCommand `cmd:"" name:"create-contract-account" help:"create new contract account"`
+	Withdraw                currencycmds.WithdrawCommand              `cmd:"" name:"withdraw" help:"withdraw amounts from target contract account"`
+	CreateCredentialService CreateCredentialServiceCommand            `cmd:"" name:"create-credential-service" help:"register credential service to contract account"`
+	AddTemplate             AddTemplateCommand                        `cmd:"" name:"add-template" help:"add template to credential service"`
+	AssignCredentials       AssignCredentialsCommand                  `cmd:"" name:"assign-credential" help:"assign credential"`
+	RevokeCredentials       RevokeCredentialsCommand                  `cmd:"" name:"revoke-credential" help:"revoke credential"`
+	CurrencyRegister        currencycmds.CurrencyRegisterCommand      `cmd:"" name:"currency-register" help:"register new currency"`
+	CurrencyPolicyUpdater   currencycmds.CurrencyPolicyUpdaterCommand `cmd:"" name:"currency-policy-updater" help:"update currency policy"`
+	SuffrageInflation       currencycmds.SuffrageInflationCommand     `cmd:"" name:"suffrage-inflation" help:"suffrage inflation operation"`
+	SuffrageCandidate       currencycmds.SuffrageCandidateCommand     `cmd:"" name:"suffrage-candidate" help:"suffrage candidate operation"`
+	SuffrageJoin            currencycmds.SuffrageJoinCommand          `cmd:"" name:"suffrage-join" help:"suffrage join operation"`
+	SuffrageDisjoin         currencycmds.SuffrageDisjoinCommand       `cmd:"" name:"suffrage-disjoin" help:"suffrage disjoin operation"` // revive:disable-line:line-length-limit
 }
 
 func NewOperationCommand() OperationCommand {
@@ -28,8 +27,8 @@ func NewOperationCommand() OperationCommand {
 		CreateAccount:           currencycmds.NewCreateAccountCommand(),
 		KeyUpdater:              currencycmds.NewKeyUpdaterCommand(),
 		Transfer:                currencycmds.NewTransferCommand(),
-		CreateContractAccount:   extensioncurrencycmds.NewCreateContractAccountCommand(),
-		Withdraw:                extensioncurrencycmds.NewWithdrawCommand(),
+		CreateContractAccount:   currencycmds.NewCreateContractAccountCommand(),
+		Withdraw:                currencycmds.NewWithdrawCommand(),
 		CreateCredentialService: NewCreateCredentialServiceCommand(),
 		AddTemplate:             NewAddTemplateCommand(),
 		AssignCredentials:       NewAssignCredentialsCommand(),

--- a/cmds/process_digest_api.go
+++ b/cmds/process_digest_api.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/ProtoconNet/mitum-currency-extension/v2/digest"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
+	"github.com/ProtoconNet/mitum-currency/v3/digest"
 	"github.com/ProtoconNet/mitum2/base"
 	isaacnetwork "github.com/ProtoconNet/mitum2/isaac/network"
 	"github.com/ProtoconNet/mitum2/launch"

--- a/cmds/process_digest_database.go
+++ b/cmds/process_digest_database.go
@@ -3,14 +3,14 @@ package cmds
 import (
 	"context"
 
-	mongodbstorage "github.com/ProtoconNet/mitum-currency-extension/v2/digest/mongodb"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
+	mongodbstorage "github.com/ProtoconNet/mitum-currency/v3/digest/mongodb"
 	isaacdatabase "github.com/ProtoconNet/mitum2/isaac/database"
 	"github.com/ProtoconNet/mitum2/launch"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/logging"
 
-	"github.com/ProtoconNet/mitum-currency-extension/v2/digest"
+	"github.com/ProtoconNet/mitum-currency/v3/digest"
 )
 
 const ProcessNameDigestDatabase = "digest_database"

--- a/cmds/process_digester.go
+++ b/cmds/process_digester.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ProtoconNet/mitum2/util/ps"
 	"github.com/pkg/errors"
 
-	"github.com/ProtoconNet/mitum-currency-extension/v2/digest"
+	"github.com/ProtoconNet/mitum-currency/v3/digest"
 )
 
 const (

--- a/cmds/run_node.go
+++ b/cmds/run_node.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ProtoconNet/mitum-currency-extension/v2/digest"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
+	"github.com/ProtoconNet/mitum-currency/v3/digest"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/isaac"
 	isaacnetwork "github.com/ProtoconNet/mitum2/isaac/network"

--- a/cmds/util.go
+++ b/cmds/util.go
@@ -18,13 +18,12 @@ import (
 	"time"
 
 	"github.com/ProtoconNet/mitum-credential/credential"
-	extensioncurrencycmds "github.com/ProtoconNet/mitum-currency-extension/v2/cmds"
-	"github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	mongodbstorage "github.com/ProtoconNet/mitum-currency-extension/v2/digest/mongodb"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
-	mitumcurrency "github.com/ProtoconNet/mitum-currency/v2/currency"
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
-	isaacoperation "github.com/ProtoconNet/mitum-currency/v2/isaac"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
+	mongodbstorage "github.com/ProtoconNet/mitum-currency/v3/digest/mongodb"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
+	mitumcurrency "github.com/ProtoconNet/mitum-currency/v3/operation/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/operation/extension"
+	isaacoperation "github.com/ProtoconNet/mitum-currency/v3/operation/isaac"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/isaac"
 	isaacblock "github.com/ProtoconNet/mitum2/isaac/block"
@@ -167,14 +166,14 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 	set := hint.NewCompatibleSet()
 
 	opr := credential.NewOperationProcessor()
-	opr.SetProcessor(mitumcurrency.CreateAccountsHint, currency.NewCreateAccountsProcessor())
-	opr.SetProcessor(mitumcurrency.KeyUpdaterHint, currency.NewKeyUpdaterProcessor())
-	opr.SetProcessor(mitumcurrency.TransfersHint, currency.NewTransfersProcessor())
-	opr.SetProcessor(currency.CurrencyRegisterHint, currency.NewCurrencyRegisterProcessor(params.Threshold()))
-	opr.SetProcessor(currency.CurrencyPolicyUpdaterHint, currency.NewCurrencyPolicyUpdaterProcessor(params.Threshold()))
-	opr.SetProcessor(mitumcurrency.SuffrageInflationHint, currency.NewSuffrageInflationProcessor(params.Threshold()))
-	opr.SetProcessor(currency.CreateContractAccountsHint, currency.NewCreateContractAccountsProcessor())
-	opr.SetProcessor(currency.WithdrawsHint, currency.NewWithdrawsProcessor())
+	opr.SetProcessor(mitumcurrency.CreateAccountsHint, mitumcurrency.NewCreateAccountsProcessor())
+	opr.SetProcessor(mitumcurrency.KeyUpdaterHint, mitumcurrency.NewKeyUpdaterProcessor())
+	opr.SetProcessor(mitumcurrency.TransfersHint, mitumcurrency.NewTransfersProcessor())
+	opr.SetProcessor(mitumcurrency.CurrencyRegisterHint, mitumcurrency.NewCurrencyRegisterProcessor(params.Threshold()))
+	opr.SetProcessor(mitumcurrency.CurrencyPolicyUpdaterHint, mitumcurrency.NewCurrencyPolicyUpdaterProcessor(params.Threshold()))
+	opr.SetProcessor(mitumcurrency.SuffrageInflationHint, mitumcurrency.NewSuffrageInflationProcessor(params.Threshold()))
+	opr.SetProcessor(extensioncurrency.CreateContractAccountsHint, extensioncurrency.NewCreateContractAccountsProcessor())
+	opr.SetProcessor(extensioncurrency.WithdrawsHint, extensioncurrency.NewWithdrawsProcessor())
 	opr.SetProcessor(credential.CreateCredentialServiceHint, credential.NewCreateCredentialServiceProcessor())
 	opr.SetProcessor(credential.AddTemplateHint, credential.NewAddTemplateProcessor())
 	opr.SetProcessor(credential.AssignCredentialsHint, credential.NewAssignCredentialsProcessor())
@@ -207,7 +206,7 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 		)
 	})
 
-	_ = set.Add(currency.CurrencyRegisterHint, func(height base.Height) (base.OperationProcessor, error) {
+	_ = set.Add(mitumcurrency.CurrencyRegisterHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
 			height,
 			db.State,
@@ -216,7 +215,7 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 		)
 	})
 
-	_ = set.Add(currency.CurrencyPolicyUpdaterHint, func(height base.Height) (base.OperationProcessor, error) {
+	_ = set.Add(mitumcurrency.CurrencyPolicyUpdaterHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
 			height,
 			db.State,
@@ -234,7 +233,7 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 		)
 	})
 
-	_ = set.Add(currency.CreateContractAccountsHint, func(height base.Height) (base.OperationProcessor, error) {
+	_ = set.Add(extensioncurrency.CreateContractAccountsHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
 			height,
 			db.State,
@@ -243,7 +242,7 @@ func POperationProcessorsMap(ctx context.Context) (context.Context, error) {
 		)
 	})
 
-	_ = set.Add(currency.WithdrawsHint, func(height base.Height) (base.OperationProcessor, error) {
+	_ = set.Add(extensioncurrency.WithdrawsHint, func(height base.Height) (base.OperationProcessor, error) {
 		return opr.New(
 			height,
 			db.State,
@@ -369,7 +368,7 @@ func PGenerateGenesis(ctx context.Context) (context.Context, error) {
 		return ctx, e(err, "")
 	}
 
-	g := extensioncurrencycmds.NewGenesisBlockGenerator(
+	g := currencycmds.NewGenesisBlockGenerator(
 		local,
 		params.NetworkID(),
 		enc,

--- a/credential/add_template.go
+++ b/credential/add_template.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -18,7 +17,7 @@ type AddTemplateFact struct {
 	base.BaseFact
 	sender              base.Address
 	contract            base.Address
-	credentialServiceID extensioncurrency.ContractID
+	credentialServiceID currencybase.ContractID
 	templateID          Uint256
 	templateName        string
 	serviceDate         Date
@@ -29,14 +28,14 @@ type AddTemplateFact struct {
 	subjectKey          string
 	description         string
 	creator             base.Address
-	currency            currency.CurrencyID
+	currency            currencybase.CurrencyID
 }
 
 func NewAddTemplateFact(
 	token []byte,
 	sender base.Address,
 	contract base.Address,
-	credentialServiceID extensioncurrency.ContractID,
+	credentialServiceID currencybase.ContractID,
 	templateID Uint256,
 	templateName string,
 	serviceDate Date,
@@ -47,7 +46,7 @@ func NewAddTemplateFact(
 	subjectKey string,
 	description string,
 	creator base.Address,
-	currency currency.CurrencyID,
+	currency currencybase.CurrencyID,
 ) AddTemplateFact {
 	bf := base.NewBaseFact(AddTemplateFactHint, token)
 	fact := AddTemplateFact{
@@ -101,7 +100,7 @@ func (fact AddTemplateFact) Bytes() []byte {
 }
 
 func (fact AddTemplateFact) IsValid(b []byte) error {
-	if err := currency.IsValidOperationFact(fact, b); err != nil {
+	if err := currencybase.IsValidOperationFact(fact, b); err != nil {
 		return err
 	}
 
@@ -152,7 +151,7 @@ func (fact AddTemplateFact) IsValid(b []byte) error {
 		return err
 	}
 
-	if expire.Compare(service) <= 0 {
+	if expire.UnixNano() < service.UnixNano() {
 		return util.ErrInvalid.Errorf("expire date <= service date, %s <= %s", fact.expirationDate, fact.serviceDate)
 	}
 
@@ -171,7 +170,7 @@ func (fact AddTemplateFact) Contract() base.Address {
 	return fact.contract
 }
 
-func (fact AddTemplateFact) CredentialServiceID() extensioncurrency.ContractID {
+func (fact AddTemplateFact) CredentialServiceID() currencybase.ContractID {
 	return fact.credentialServiceID
 }
 
@@ -215,7 +214,7 @@ func (fact AddTemplateFact) Creator() base.Address {
 	return fact.creator
 }
 
-func (fact AddTemplateFact) Currency() currency.CurrencyID {
+func (fact AddTemplateFact) Currency() currencybase.CurrencyID {
 	return fact.currency
 }
 
@@ -228,11 +227,11 @@ func (fact AddTemplateFact) Addresses() ([]base.Address, error) {
 }
 
 type AddTemplate struct {
-	currency.BaseOperation
+	currencybase.BaseOperation
 }
 
 func NewAddTemplate(fact AddTemplateFact) (AddTemplate, error) {
-	return AddTemplate{BaseOperation: currency.NewBaseOperation(AddTemplateHint, fact)}, nil
+	return AddTemplate{BaseOperation: currencybase.NewBaseOperation(AddTemplateHint, fact)}, nil
 }
 
 func (op *AddTemplate) HashSign(priv base.Privatekey, networkID base.NetworkID) error {

--- a/credential/add_template_bson.go
+++ b/credential/add_template_bson.go
@@ -3,8 +3,8 @@ package credential // nolint: dupl
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	"github.com/ProtoconNet/mitum-currency/v3/base"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"github.com/ProtoconNet/mitum2/util/valuehash"
@@ -55,7 +55,7 @@ type AddTemplateFactBSONUnmarshaler struct {
 func (fact *AddTemplateFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of AddTemplateFact")
 
-	var ubf currency.BaseFactBSONUnmarshaler
+	var ubf base.BaseFactBSONUnmarshaler
 
 	if err := enc.Unmarshal(b, &ubf); err != nil {
 		return e(err, "")
@@ -105,7 +105,7 @@ func (op AddTemplate) MarshalBSON() ([]byte, error) {
 func (op *AddTemplate) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of AddTemplate")
 
-	var ubo currency.BaseOperation
+	var ubo base.BaseOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/add_template_encode.go
+++ b/credential/add_template_encode.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/encoder"
@@ -15,7 +14,7 @@ func (fact *AddTemplateFact) unpack(enc encoder.Encoder,
 ) error {
 	e := util.StringErrorFunc("failed to unmarshal AddTemplateFact")
 
-	fact.credentialServiceID = extensioncurrency.ContractID(csid)
+	fact.credentialServiceID = currencybase.ContractID(csid)
 	fact.templateName = tname
 	fact.serviceDate = Date(sd)
 	fact.expirationDate = Date(ed)
@@ -24,7 +23,7 @@ func (fact *AddTemplateFact) unpack(enc encoder.Encoder,
 	fact.displayName = dn
 	fact.subjectKey = sk
 	fact.description = desc
-	fact.currency = currency.CurrencyID(cid)
+	fact.currency = currencybase.CurrencyID(cid)
 
 	templateid, err := NewUint256FromString(tid)
 	if err != nil {

--- a/credential/add_template_json.go
+++ b/credential/add_template_json.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -10,20 +9,20 @@ import (
 
 type AddTemplateFactJSONMarshaler struct {
 	base.BaseFactJSONMarshaler
-	Owner               base.Address                 `json:"sender"`
-	Contract            base.Address                 `json:"contract"`
-	CredentialServiceID extensioncurrency.ContractID `json:"credential_service_id"`
-	TemplateID          Uint256                      `json:"template_id"`
-	TemplateName        string                       `json:"template_name"`
-	ServiceDate         Date                         `json:"service_date"`
-	ExpirationDate      Date                         `json:"expiration_date"`
-	TemplateShare       Bool                         `json:"temcdplate_share"`
-	MultiAudit          Bool                         `json:"multi_audit"`
-	DisplayName         string                       `json:"display_name"`
-	SubjectKey          string                       `json:"subject_key"`
-	Description         string                       `json:"description"`
-	Creator             base.Address                 `json:"creator"`
-	Currency            currency.CurrencyID          `json:"currency"`
+	Owner               base.Address            `json:"sender"`
+	Contract            base.Address            `json:"contract"`
+	CredentialServiceID currencybase.ContractID `json:"credential_service_id"`
+	TemplateID          Uint256                 `json:"template_id"`
+	TemplateName        string                  `json:"template_name"`
+	ServiceDate         Date                    `json:"service_date"`
+	ExpirationDate      Date                    `json:"expiration_date"`
+	TemplateShare       Bool                    `json:"temcdplate_share"`
+	MultiAudit          Bool                    `json:"multi_audit"`
+	DisplayName         string                  `json:"display_name"`
+	SubjectKey          string                  `json:"subject_key"`
+	Description         string                  `json:"description"`
+	Creator             base.Address            `json:"creator"`
+	Currency            currencybase.CurrencyID `json:"currency"`
 }
 
 func (fact AddTemplateFact) MarshalJSON() ([]byte, error) {
@@ -93,7 +92,7 @@ func (fact *AddTemplateFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 }
 
 type AddTemplateMarshaler struct {
-	currency.BaseOperationJSONMarshaler
+	currencybase.BaseOperationJSONMarshaler
 }
 
 func (op AddTemplate) MarshalJSON() ([]byte, error) {
@@ -105,7 +104,7 @@ func (op AddTemplate) MarshalJSON() ([]byte, error) {
 func (op *AddTemplate) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of AddTemplate")
 
-	var ubo currency.BaseOperation
+	var ubo currencybase.BaseOperation
 	if err := ubo.DecodeJSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/add_template_process.go
+++ b/credential/add_template_process.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"sync"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
+	types "github.com/ProtoconNet/mitum-currency/v3/operation/type"
+	currency "github.com/ProtoconNet/mitum-currency/v3/state/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/state/extension"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/pkg/errors"
@@ -27,7 +29,7 @@ type AddTemplateProcessor struct {
 	*base.BaseOperationProcessor
 }
 
-func NewAddTemplateProcessor() extensioncurrency.GetNewProcessor {
+func NewAddTemplateProcessor() types.GetNewProcessor {
 	return func(
 		height base.Height,
 		getStateFunc base.GetStateFunc,
@@ -190,7 +192,7 @@ func (opp *AddTemplateProcessor) Process(
 		return nil, base.NewBaseOperationProcessReasonError("currency not found, %q: %w", fact.Currency(), err), nil
 	}
 
-	fee, err := currencyPolicy.Feeer().Fee(currency.ZeroBig)
+	fee, err := currencyPolicy.Feeer().Fee(currencybase.ZeroBig)
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("failed to check fee of currency, %q: %w", fact.Currency(), err), nil
 	}
@@ -199,7 +201,8 @@ func (opp *AddTemplateProcessor) Process(
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("sender balance not found, %q: %w", fact.Sender(), err), nil
 	}
-	sb := currency.NewBalanceStateMergeValue(st.Key(), st.Value())
+
+	sb := NewStateMergeValue(st.Key(), st.Value())
 
 	switch b, err := currency.StateBalanceValue(st); {
 	case err != nil:
@@ -212,10 +215,7 @@ func (opp *AddTemplateProcessor) Process(
 	if !ok {
 		return nil, base.NewBaseOperationProcessReasonError("expected BalanceStateValue, not %T", sb.Value()), nil
 	}
-	sts[2] = currency.NewBalanceStateMergeValue(
-		sb.Key(),
-		currency.NewBalanceStateValue(v.Amount.WithBig(v.Amount.Big().Sub(fee))),
-	)
+	sts[2] = NewStateMergeValue(sb.Key(), currency.NewBalanceStateValue(v.Amount.WithBig(v.Amount.Big().Sub(fee))))
 
 	return sts, nil, nil
 }

--- a/credential/assign_credentials.go
+++ b/credential/assign_credentials.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"fmt"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -13,7 +13,7 @@ import (
 type CredentialItem interface {
 	util.Byter
 	util.IsValider
-	Currency() currency.CurrencyID
+	Currency() currencybase.CurrencyID
 }
 
 var (
@@ -67,7 +67,7 @@ func (fact AssignCredentialsFact) IsValid(b []byte) error {
 		return err
 	}
 
-	if err := currency.IsValidOperationFact(fact, b); err != nil {
+	if err := currencybase.IsValidOperationFact(fact, b); err != nil {
 		return err
 	}
 
@@ -133,11 +133,11 @@ func (fact AssignCredentialsFact) Addresses() ([]base.Address, error) {
 }
 
 type AssignCredentials struct {
-	currency.BaseOperation
+	currencybase.BaseOperation
 }
 
 func NewAssignCredentials(fact AssignCredentialsFact) (AssignCredentials, error) {
-	return AssignCredentials{BaseOperation: currency.NewBaseOperation(AssignCredentialsHint, fact)}, nil
+	return AssignCredentials{BaseOperation: currencybase.NewBaseOperation(AssignCredentialsHint, fact)}, nil
 }
 
 func (op *AssignCredentials) HashSign(priv base.Privatekey, networkID base.NetworkID) error {

--- a/credential/assign_credentials_bson.go
+++ b/credential/assign_credentials_bson.go
@@ -3,8 +3,8 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	"github.com/ProtoconNet/mitum-currency/v3/base"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"github.com/ProtoconNet/mitum2/util/valuehash"
@@ -31,7 +31,7 @@ type AssignCredentialsFactBSONUnmarshaler struct {
 func (fact *AssignCredentialsFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of AssignCredentialsFact")
 
-	var ubf currency.BaseFactBSONUnmarshaler
+	var ubf base.BaseFactBSONUnmarshaler
 
 	if err := enc.Unmarshal(b, &ubf); err != nil {
 		return e(err, "")
@@ -67,7 +67,7 @@ func (op AssignCredentials) MarshalBSON() ([]byte, error) {
 func (op *AssignCredentials) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of AssignCredentials")
 
-	var ubo currency.BaseOperation
+	var ubo base.BaseOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/assign_credentials_item.go
+++ b/credential/assign_credentials_item.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -13,7 +12,7 @@ var AssignCredentialsItemHint = hint.MustNewHint("mitum-credential-assign-creden
 type AssignCredentialsItem struct {
 	hint.BaseHinter
 	contract            base.Address
-	credentialServiceID extensioncurrency.ContractID
+	credentialServiceID currencybase.ContractID
 	holder              base.Address
 	templateID          Uint256
 	id                  string
@@ -21,12 +20,12 @@ type AssignCredentialsItem struct {
 	validfrom           Uint256
 	validuntil          Uint256
 	did                 string
-	currency            currency.CurrencyID
+	currency            currencybase.CurrencyID
 }
 
 func NewAssignCredentialsItem(
 	contract base.Address,
-	credentialServiceID extensioncurrency.ContractID,
+	credentialServiceID currencybase.ContractID,
 	holder base.Address,
 	templateID Uint256,
 	id string,
@@ -34,7 +33,7 @@ func NewAssignCredentialsItem(
 	validfrom Uint256,
 	validuntil Uint256,
 	did string,
-	currency currency.CurrencyID,
+	currency currencybase.CurrencyID,
 ) AssignCredentialsItem {
 	return AssignCredentialsItem{
 		BaseHinter:          hint.NewBaseHinter(AssignCredentialsItemHint),
@@ -103,7 +102,7 @@ func (it AssignCredentialsItem) IsValid([]byte) error {
 	return nil
 }
 
-func (it AssignCredentialsItem) CredentialServiceID() extensioncurrency.ContractID {
+func (it AssignCredentialsItem) CredentialServiceID() currencybase.ContractID {
 	return it.credentialServiceID
 }
 
@@ -139,7 +138,7 @@ func (it AssignCredentialsItem) DID() string {
 	return it.did
 }
 
-func (it AssignCredentialsItem) Currency() currency.CurrencyID {
+func (it AssignCredentialsItem) Currency() currencybase.CurrencyID {
 	return it.currency
 }
 

--- a/credential/assign_credentials_item_bson.go
+++ b/credential/assign_credentials_item_bson.go
@@ -1,7 +1,7 @@
 package credential // nolint:dupl
 
 import (
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"go.mongodb.org/mongo-driver/bson"

--- a/credential/assign_credentials_item_encode.go
+++ b/credential/assign_credentials_item_encode.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/encoder"
@@ -15,11 +14,11 @@ func (it *AssignCredentialsItem) unpack(enc encoder.Encoder, ht hint.Hint,
 	e := util.StringErrorFunc("failed to unmarshal AssignCredentialsItem")
 
 	it.BaseHinter = hint.NewBaseHinter(ht)
-	it.credentialServiceID = extensioncurrency.ContractID(csid)
+	it.credentialServiceID = currencybase.ContractID(csid)
 	it.id = id
 	it.value = v
 	it.did = did
-	it.currency = currency.CurrencyID(cid)
+	it.currency = currencybase.CurrencyID(cid)
 
 	switch a, err := base.DecodeAddress(ca, enc); {
 	case err != nil:

--- a/credential/assign_credentials_item_json.go
+++ b/credential/assign_credentials_item_json.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -11,16 +10,16 @@ import (
 
 type AssignCredentialsItemJSONMarshaler struct {
 	hint.BaseHinter
-	Contract          base.Address                 `json:"contract"`
-	CredentialService extensioncurrency.ContractID `json:"credential_service_id"`
-	Holder            base.Address                 `json:"holder"`
-	TemplateID        Uint256                      `json:"template_id"`
-	ID                string                       `json:"id"`
-	Value             string                       `json:"value"`
-	ValidFrom         Uint256                      `json:"valid_from"`
-	ValidUntil        Uint256                      `json:"valid_until"`
-	DID               string                       `json:"did"`
-	Currency          currency.CurrencyID          `json:"currency"`
+	Contract          base.Address            `json:"contract"`
+	CredentialService currencybase.ContractID `json:"credential_service_id"`
+	Holder            base.Address            `json:"holder"`
+	TemplateID        Uint256                 `json:"template_id"`
+	ID                string                  `json:"id"`
+	Value             string                  `json:"value"`
+	ValidFrom         Uint256                 `json:"valid_from"`
+	ValidUntil        Uint256                 `json:"valid_until"`
+	DID               string                  `json:"did"`
+	Currency          currencybase.CurrencyID `json:"currency"`
 }
 
 func (it AssignCredentialsItem) MarshalJSON() ([]byte, error) {

--- a/credential/assign_credentials_json.go
+++ b/credential/assign_credentials_json.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"encoding/json"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -43,7 +43,7 @@ func (fact *AssignCredentialsFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) er
 }
 
 type AssignCredentialsMarshaler struct {
-	currency.BaseOperationJSONMarshaler
+	currencybase.BaseOperationJSONMarshaler
 }
 
 func (op AssignCredentials) MarshalJSON() ([]byte, error) {
@@ -55,7 +55,7 @@ func (op AssignCredentials) MarshalJSON() ([]byte, error) {
 func (op *AssignCredentials) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of AssignCredentials")
 
-	var ubo currency.BaseOperation
+	var ubo currencybase.BaseOperation
 	if err := ubo.DecodeJSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/create_credential_service.go
+++ b/credential/create_credential_service.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -18,16 +17,16 @@ type CreateCredentialServiceFact struct {
 	base.BaseFact
 	sender              base.Address
 	contract            base.Address
-	credentialServiceID extensioncurrency.ContractID
-	currency            currency.CurrencyID
+	credentialServiceID currencybase.ContractID
+	currency            currencybase.CurrencyID
 }
 
 func NewCreateCredentialServiceFact(
 	token []byte,
 	sender base.Address,
 	contract base.Address,
-	credentialServiceID extensioncurrency.ContractID,
-	currency currency.CurrencyID,
+	credentialServiceID currencybase.ContractID,
+	currency currencybase.CurrencyID,
 ) CreateCredentialServiceFact {
 	bf := base.NewBaseFact(CreateCredentialServiceFactHint, token)
 	fact := CreateCredentialServiceFact{
@@ -65,7 +64,7 @@ func (fact CreateCredentialServiceFact) IsValid(b []byte) error {
 		return err
 	}
 
-	if err := currency.IsValidOperationFact(fact, b); err != nil {
+	if err := currencybase.IsValidOperationFact(fact, b); err != nil {
 		return err
 	}
 
@@ -92,11 +91,11 @@ func (fact CreateCredentialServiceFact) Contract() base.Address {
 	return fact.contract
 }
 
-func (fact CreateCredentialServiceFact) CredentialServiceID() extensioncurrency.ContractID {
+func (fact CreateCredentialServiceFact) CredentialServiceID() currencybase.ContractID {
 	return fact.credentialServiceID
 }
 
-func (fact CreateCredentialServiceFact) Currency() currency.CurrencyID {
+func (fact CreateCredentialServiceFact) Currency() currencybase.CurrencyID {
 	return fact.currency
 }
 
@@ -110,11 +109,11 @@ func (fact CreateCredentialServiceFact) Addresses() ([]base.Address, error) {
 }
 
 type CreateCredentialService struct {
-	currency.BaseOperation
+	currencybase.BaseOperation
 }
 
 func NewCreateCredentialService(fact CreateCredentialServiceFact) (CreateCredentialService, error) {
-	return CreateCredentialService{BaseOperation: currency.NewBaseOperation(CreateCredentialServiceHint, fact)}, nil
+	return CreateCredentialService{BaseOperation: currencybase.NewBaseOperation(CreateCredentialServiceHint, fact)}, nil
 }
 
 func (op *CreateCredentialService) HashSign(priv base.Privatekey, networkID base.NetworkID) error {

--- a/credential/create_credential_service_bson.go
+++ b/credential/create_credential_service_bson.go
@@ -3,8 +3,8 @@ package credential // nolint: dupl
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	"github.com/ProtoconNet/mitum-currency/v3/base"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"github.com/ProtoconNet/mitum2/util/valuehash"
@@ -35,7 +35,7 @@ type CreateCredentialServiceFactBSONUnmarshaler struct {
 func (fact *CreateCredentialServiceFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of CreateCredentialServiceFact")
 
-	var ubf currency.BaseFactBSONUnmarshaler
+	var ubf base.BaseFactBSONUnmarshaler
 
 	if err := enc.Unmarshal(b, &ubf); err != nil {
 		return e(err, "")
@@ -71,7 +71,7 @@ func (op CreateCredentialService) MarshalBSON() ([]byte, error) {
 func (op *CreateCredentialService) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of CreateCredentialService")
 
-	var ubo currency.BaseOperation
+	var ubo base.BaseOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/create_credential_service_encode.go
+++ b/credential/create_credential_service_encode.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/encoder"
@@ -25,8 +24,8 @@ func (fact *CreateCredentialServiceFact) unpack(enc encoder.Encoder, sa, ca, csi
 		fact.contract = a
 	}
 
-	fact.credentialServiceID = extensioncurrency.ContractID(csid)
-	fact.currency = currency.CurrencyID(cid)
+	fact.credentialServiceID = currencybase.ContractID(csid)
+	fact.currency = currencybase.CurrencyID(cid)
 
 	return nil
 }

--- a/credential/create_credential_service_json.go
+++ b/credential/create_credential_service_json.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -10,10 +9,10 @@ import (
 
 type CreateCredentialServiceFactJSONMarshaler struct {
 	base.BaseFactJSONMarshaler
-	Owner               base.Address                 `json:"sender"`
-	Contract            base.Address                 `json:"contract"`
-	CredentialServiceID extensioncurrency.ContractID `json:"credential_service_id"`
-	Currency            currency.CurrencyID          `json:"currency"`
+	Owner               base.Address            `json:"sender"`
+	Contract            base.Address            `json:"contract"`
+	CredentialServiceID currencybase.ContractID `json:"credential_service_id"`
+	Currency            currencybase.CurrencyID `json:"currency"`
 }
 
 func (fact CreateCredentialServiceFact) MarshalJSON() ([]byte, error) {
@@ -48,7 +47,7 @@ func (fact *CreateCredentialServiceFact) DecodeJSON(b []byte, enc *jsonenc.Encod
 }
 
 type CreateCredentialServiceMarshaler struct {
-	currency.BaseOperationJSONMarshaler
+	currencybase.BaseOperationJSONMarshaler
 }
 
 func (op CreateCredentialService) MarshalJSON() ([]byte, error) {
@@ -60,7 +59,7 @@ func (op CreateCredentialService) MarshalJSON() ([]byte, error) {
 func (op *CreateCredentialService) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of CreateCredentialService")
 
-	var ubo currency.BaseOperation
+	var ubo currencybase.BaseOperation
 	if err := ubo.DecodeJSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/create_credential_service_process.go
+++ b/credential/create_credential_service_process.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"sync"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
+	types "github.com/ProtoconNet/mitum-currency/v3/operation/type"
+	currency "github.com/ProtoconNet/mitum-currency/v3/state/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/state/extension"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/pkg/errors"
@@ -27,7 +29,7 @@ type CreateCredentialServiceProcessor struct {
 	*base.BaseOperationProcessor
 }
 
-func NewCreateCredentialServiceProcessor() extensioncurrency.GetNewProcessor {
+func NewCreateCredentialServiceProcessor() types.GetNewProcessor {
 	return func(
 		height base.Height,
 		getStateFunc base.GetStateFunc,
@@ -137,7 +139,7 @@ func (opp *CreateCredentialServiceProcessor) Process(
 		return nil, base.NewBaseOperationProcessReasonError("currency not found, %q: %w", fact.Currency(), err), nil
 	}
 
-	fee, err := currencyPolicy.Feeer().Fee(currency.ZeroBig)
+	fee, err := currencyPolicy.Feeer().Fee(currencybase.ZeroBig)
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("failed to check fee of currency, %q: %w", fact.Currency(), err), nil
 	}
@@ -146,7 +148,7 @@ func (opp *CreateCredentialServiceProcessor) Process(
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("sender balance not found, %q: %w", fact.Sender(), err), nil
 	}
-	sb := currency.NewBalanceStateMergeValue(st.Key(), st.Value())
+	sb := NewStateMergeValue(st.Key(), st.Value())
 
 	switch b, err := currency.StateBalanceValue(st); {
 	case err != nil:
@@ -159,10 +161,7 @@ func (opp *CreateCredentialServiceProcessor) Process(
 	if !ok {
 		return nil, base.NewBaseOperationProcessReasonError("expected BalanceStateValue, not %T", sb.Value()), nil
 	}
-	sts[1] = currency.NewBalanceStateMergeValue(
-		sb.Key(),
-		currency.NewBalanceStateValue(v.Amount.WithBig(v.Amount.Big().Sub(fee))),
-	)
+	sts[1] = NewStateMergeValue(sb.Key(), currency.NewBalanceStateValue(v.Amount.WithBig(v.Amount.Big().Sub(fee))))
 
 	return sts, nil, nil
 }

--- a/credential/credential_bson.go
+++ b/credential/credential_bson.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 )

--- a/credential/design.go
+++ b/credential/design.go
@@ -1,7 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 )
@@ -10,11 +10,11 @@ var DesignHint = hint.MustNewHint("mitum-credential-design-v0.0.1")
 
 type Design struct {
 	hint.BaseHinter
-	credentialServiceID extensioncurrency.ContractID
+	credentialServiceID currencybase.ContractID
 	policy              Policy
 }
 
-func NewDesign(credentialServiceID extensioncurrency.ContractID, policy Policy) Design {
+func NewDesign(credentialServiceID currencybase.ContractID, policy Policy) Design {
 	return Design{
 		BaseHinter:          hint.NewBaseHinter(DesignHint),
 		credentialServiceID: credentialServiceID,
@@ -41,7 +41,7 @@ func (de Design) Bytes() []byte {
 	)
 }
 
-func (de Design) CredentialServiceID() extensioncurrency.ContractID {
+func (de Design) CredentialServiceID() currencybase.ContractID {
 	return de.credentialServiceID
 }
 

--- a/credential/design_bson.go
+++ b/credential/design_bson.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 )

--- a/credential/design_encode.go
+++ b/credential/design_encode.go
@@ -1,7 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/encoder"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -11,7 +11,7 @@ func (de *Design) unpack(enc encoder.Encoder, ht hint.Hint, credit string, bpo [
 	e := util.StringErrorFunc("failed to decode bson of Design")
 
 	de.BaseHinter = hint.NewBaseHinter(ht)
-	de.credentialServiceID = extensioncurrency.ContractID(credit)
+	de.credentialServiceID = currencybase.ContractID(credit)
 
 	if hinter, err := enc.Decode(bpo); err != nil {
 		return e(err, "")

--- a/credential/design_json.go
+++ b/credential/design_json.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"encoding/json"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -11,8 +11,8 @@ import (
 
 type DesignJSONMarshaler struct {
 	hint.BaseHinter
-	Credential extensioncurrency.ContractID `json:"credential_service_id"`
-	Policy     Policy                       `json:"policy"`
+	Credential currencybase.ContractID `json:"credential_service_id"`
+	Policy     Policy                  `json:"policy"`
 }
 
 func (de Design) MarshalJSON() ([]byte, error) {

--- a/credential/keys.go
+++ b/credential/keys.go
@@ -1,12 +1,12 @@
 package credential
 
 import (
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/pkg/errors"
 )
 
-func checkThreshold(fs []base.Sign, keys currency.AccountKeys) error {
+func checkThreshold(fs []base.Sign, keys currencybase.AccountKeys) error {
 	var sum uint
 	for i := range fs {
 		ky, found := keys.Key(fs[i].Signer())

--- a/credential/operation_processor.go
+++ b/credential/operation_processor.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"sync"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
+	currency "github.com/ProtoconNet/mitum-currency/v3/operation/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/operation/extension"
+	types "github.com/ProtoconNet/mitum-currency/v3/operation/type"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -37,7 +39,7 @@ type OperationProcessor struct {
 	*logging.Logging
 	*base.BaseOperationProcessor
 	processorHintSet     *hint.CompatibleSet
-	fee                  map[currency.CurrencyID]currency.Big
+	fee                  map[currencybase.CurrencyID]currencybase.Big
 	duplicated           map[string]DuplicationType
 	duplicatedNewAddress map[string]struct{}
 	processorClosers     *sync.Map
@@ -51,7 +53,7 @@ func NewOperationProcessor() *OperationProcessor {
 			return c.Str("module", "mitum-credential-operations-processor")
 		}),
 		processorHintSet:     hint.NewCompatibleSet(),
-		fee:                  map[currency.CurrencyID]currency.Big{},
+		fee:                  map[currencybase.CurrencyID]currencybase.Big{},
 		duplicated:           map[string]DuplicationType{},
 		duplicatedNewAddress: map[string]struct{}{},
 		processorClosers:     &m,
@@ -99,7 +101,7 @@ func (opr *OperationProcessor) New(
 
 func (opr *OperationProcessor) SetProcessor(
 	hint hint.Hint,
-	newProcessor extensioncurrency.GetNewProcessor,
+	newProcessor types.GetNewProcessor,
 ) (base.OperationProcessor, error) {
 	if err := opr.processorHintSet.Add(hint, newProcessor); err != nil {
 		if !errors.Is(err, util.ErrFound) {
@@ -239,15 +241,15 @@ func (opr *OperationProcessor) checkDuplication(op base.Operation) error {
 		}
 		did = fact.Sender().String()
 		didtype = DuplicationTypeSender
-	case extensioncurrency.CurrencyRegister:
-		fact, ok := t.Fact().(extensioncurrency.CurrencyRegisterFact)
+	case currency.CurrencyRegister:
+		fact, ok := t.Fact().(currency.CurrencyRegisterFact)
 		if !ok {
 			return errors.Errorf("expected CurrencyRegisterFact, not %T", t.Fact())
 		}
 		did = fact.Currency().Currency().String()
 		didtype = DuplicationTypeCurrency
-	case extensioncurrency.CurrencyPolicyUpdater:
-		fact, ok := t.Fact().(extensioncurrency.CurrencyPolicyUpdaterFact)
+	case currency.CurrencyPolicyUpdater:
+		fact, ok := t.Fact().(currency.CurrencyPolicyUpdaterFact)
 		if !ok {
 			return errors.Errorf("expected CurrencyPolicyUpdaterFact, not %T", t.Fact())
 		}
@@ -328,8 +330,8 @@ func (opr *OperationProcessor) getNewProcessor(op base.Operation) (base.Operatio
 		currency.Transfers,
 		extensioncurrency.CreateContractAccounts,
 		extensioncurrency.Withdraws,
-		extensioncurrency.CurrencyRegister,
-		extensioncurrency.CurrencyPolicyUpdater,
+		currency.CurrencyRegister,
+		currency.CurrencyPolicyUpdater,
 		currency.SuffrageInflation,
 		CreateCredentialService,
 		AddTemplate,
@@ -342,13 +344,13 @@ func (opr *OperationProcessor) getNewProcessor(op base.Operation) (base.Operatio
 }
 
 func (opr *OperationProcessor) getNewProcessorFromHintset(op base.Operation) (base.OperationProcessor, error) {
-	var f extensioncurrency.GetNewProcessor
+	var f types.GetNewProcessor
 
 	if hinter, ok := op.(hint.Hinter); !ok {
 		return nil, nil
 	} else if i := opr.processorHintSet.Find(hinter.Hint()); i == nil {
 		return nil, nil
-	} else if j, ok := i.(extensioncurrency.GetNewProcessor); !ok {
+	} else if j, ok := i.(types.GetNewProcessor); !ok {
 		return nil, errors.Errorf("invalid GetNewProcessor func, %T", i)
 	} else {
 		f = j

--- a/credential/policy_bson.go
+++ b/credential/policy_bson.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 )

--- a/credential/revoke_credentials.go
+++ b/credential/revoke_credentials.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"fmt"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -61,7 +61,7 @@ func (fact RevokeCredentialsFact) IsValid(b []byte) error {
 		return err
 	}
 
-	if err := currency.IsValidOperationFact(fact, b); err != nil {
+	if err := currencybase.IsValidOperationFact(fact, b); err != nil {
 		return err
 	}
 
@@ -127,11 +127,11 @@ func (fact RevokeCredentialsFact) Addresses() ([]base.Address, error) {
 }
 
 type RevokeCredentials struct {
-	currency.BaseOperation
+	currencybase.BaseOperation
 }
 
 func NewRevokeCredentials(fact RevokeCredentialsFact) (RevokeCredentials, error) {
-	return RevokeCredentials{BaseOperation: currency.NewBaseOperation(RevokeCredentialsHint, fact)}, nil
+	return RevokeCredentials{BaseOperation: currencybase.NewBaseOperation(RevokeCredentialsHint, fact)}, nil
 }
 
 func (op *RevokeCredentials) HashSign(priv base.Privatekey, networkID base.NetworkID) error {

--- a/credential/revoke_credentials_bson.go
+++ b/credential/revoke_credentials_bson.go
@@ -3,8 +3,8 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	"github.com/ProtoconNet/mitum-currency/v3/base"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"github.com/ProtoconNet/mitum2/util/valuehash"
@@ -31,7 +31,7 @@ type RevokeCredentialsFactBSONUnmarshaler struct {
 func (fact *RevokeCredentialsFact) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of RevokeCredentialsFact")
 
-	var ubf currency.BaseFactBSONUnmarshaler
+	var ubf base.BaseFactBSONUnmarshaler
 
 	if err := enc.Unmarshal(b, &ubf); err != nil {
 		return e(err, "")
@@ -67,7 +67,7 @@ func (op RevokeCredentials) MarshalBSON() ([]byte, error) {
 func (op *RevokeCredentials) DecodeBSON(b []byte, enc *bsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode bson of RevokeCredentials")
 
-	var ubo currency.BaseOperation
+	var ubo base.BaseOperation
 	if err := ubo.DecodeBSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/revoke_credentials_item.go
+++ b/credential/revoke_credentials_item.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -13,20 +12,20 @@ var RevokeCredentialsItemHint = hint.MustNewHint("mitum-credential-revoke-creden
 type RevokeCredentialsItem struct {
 	hint.BaseHinter
 	contract            base.Address
-	credentialServiceID extensioncurrency.ContractID
+	credentialServiceID currencybase.ContractID
 	holder              base.Address
 	templateID          Uint256
 	id                  string
-	currency            currency.CurrencyID
+	currency            currencybase.CurrencyID
 }
 
 func NewRevokeCredentialsItem(
 	contract base.Address,
-	credentialServiceID extensioncurrency.ContractID,
+	credentialServiceID currencybase.ContractID,
 	holder base.Address,
 	templateID Uint256,
 	id string,
-	currency currency.CurrencyID,
+	currency currencybase.CurrencyID,
 ) RevokeCredentialsItem {
 	return RevokeCredentialsItem{
 		BaseHinter:          hint.NewBaseHinter(RevokeCredentialsItemHint),
@@ -73,7 +72,7 @@ func (it RevokeCredentialsItem) IsValid([]byte) error {
 	return nil
 }
 
-func (it RevokeCredentialsItem) CredentialServiceID() extensioncurrency.ContractID {
+func (it RevokeCredentialsItem) CredentialServiceID() currencybase.ContractID {
 	return it.credentialServiceID
 }
 
@@ -93,7 +92,7 @@ func (it RevokeCredentialsItem) ID() string {
 	return it.id
 }
 
-func (it RevokeCredentialsItem) Currency() currency.CurrencyID {
+func (it RevokeCredentialsItem) Currency() currencybase.CurrencyID {
 	return it.currency
 }
 

--- a/credential/revoke_credentials_item_bson.go
+++ b/credential/revoke_credentials_item_bson.go
@@ -1,7 +1,7 @@
 package credential // nolint:dupl
 
 import (
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"go.mongodb.org/mongo-driver/bson"

--- a/credential/revoke_credentials_item_encode.go
+++ b/credential/revoke_credentials_item_encode.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/encoder"
@@ -15,9 +14,9 @@ func (it *RevokeCredentialsItem) unpack(enc encoder.Encoder, ht hint.Hint,
 	e := util.StringErrorFunc("failed to unmarshal RevokeCredentialsItem")
 
 	it.BaseHinter = hint.NewBaseHinter(ht)
-	it.credentialServiceID = extensioncurrency.ContractID(csid)
+	it.credentialServiceID = currencybase.ContractID(csid)
 	it.id = id
-	it.currency = currency.CurrencyID(cid)
+	it.currency = currencybase.CurrencyID(cid)
 
 	switch a, err := base.DecodeAddress(ca, enc); {
 	case err != nil:

--- a/credential/revoke_credentials_item_json.go
+++ b/credential/revoke_credentials_item_json.go
@@ -1,8 +1,7 @@
 package credential
 
 import (
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -11,12 +10,12 @@ import (
 
 type RevokeCredentialsItemJSONMarshaler struct {
 	hint.BaseHinter
-	Contract          base.Address                 `json:"contract"`
-	CredentialService extensioncurrency.ContractID `json:"credential_service_id"`
-	Holder            base.Address                 `json:"holder"`
-	TemplateID        Uint256                      `json:"template_id"`
-	ID                string                       `json:"id"`
-	Currency          currency.CurrencyID          `json:"currency"`
+	Contract          base.Address            `json:"contract"`
+	CredentialService currencybase.ContractID `json:"credential_service_id"`
+	Holder            base.Address            `json:"holder"`
+	TemplateID        Uint256                 `json:"template_id"`
+	ID                string                  `json:"id"`
+	Currency          currencybase.CurrencyID `json:"currency"`
 }
 
 func (it RevokeCredentialsItem) MarshalJSON() ([]byte, error) {

--- a/credential/revoke_credentials_json.go
+++ b/credential/revoke_credentials_json.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"encoding/json"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	jsonenc "github.com/ProtoconNet/mitum2/util/encoder/json"
@@ -43,7 +43,7 @@ func (fact *RevokeCredentialsFact) DecodeJSON(b []byte, enc *jsonenc.Encoder) er
 }
 
 type RevokeCredentialsMarshaler struct {
-	currency.BaseOperationJSONMarshaler
+	currencybase.BaseOperationJSONMarshaler
 }
 
 func (op RevokeCredentials) MarshalJSON() ([]byte, error) {
@@ -55,7 +55,7 @@ func (op RevokeCredentials) MarshalJSON() ([]byte, error) {
 func (op *RevokeCredentials) DecodeJSON(b []byte, enc *jsonenc.Encoder) error {
 	e := util.StringErrorFunc("failed to decode json of RevokeCredentials")
 
-	var ubo currency.BaseOperation
+	var ubo currencybase.BaseOperation
 	if err := ubo.DecodeJSON(b, enc); err != nil {
 		return e(err, "")
 	}

--- a/credential/revoke_credentials_process.go
+++ b/credential/revoke_credentials_process.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"sync"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencyoperation "github.com/ProtoconNet/mitum-currency/v3/operation/currency"
+	types "github.com/ProtoconNet/mitum-currency/v3/operation/type"
+	currency "github.com/ProtoconNet/mitum-currency/v3/state/currency"
+	extensioncurrency "github.com/ProtoconNet/mitum-currency/v3/state/extension"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/pkg/errors"
@@ -167,7 +169,7 @@ type RevokeCredentialsProcessor struct {
 	*base.BaseOperationProcessor
 }
 
-func NewRevokeCredentialsProcessor() extensioncurrency.GetNewProcessor {
+func NewRevokeCredentialsProcessor() types.GetNewProcessor {
 	return func(
 		height base.Height,
 		getStateFunc base.GetStateFunc,
@@ -336,7 +338,7 @@ func (opp *RevokeCredentialsProcessor) Process( // nolint:dupl
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("failed to calculate fee: %w", err), nil
 	}
-	sb, err := currency.CheckEnoughBalance(fact.sender, required, getStateFunc)
+	sb, err := currencyoperation.CheckEnoughBalance(fact.sender, required, getStateFunc)
 	if err != nil {
 		return nil, base.NewBaseOperationProcessReasonError("failed to check enough balance: %w", err), nil
 	}
@@ -347,7 +349,7 @@ func (opp *RevokeCredentialsProcessor) Process( // nolint:dupl
 			return nil, nil, e(nil, "expected BalanceStateValue, not %T", sb[i].Value())
 		}
 		stv := currency.NewBalanceStateValue(v.Amount.WithBig(v.Amount.Big().Sub(required[i][0])))
-		sts = append(sts, currency.NewBalanceStateMergeValue(sb[i].Key(), stv))
+		sts = append(sts, NewStateMergeValue(sb[i].Key(), stv))
 	}
 
 	return sts, nil, nil

--- a/credential/signs.go
+++ b/credential/signs.go
@@ -1,7 +1,7 @@
 package credential
 
 import (
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currency "github.com/ProtoconNet/mitum-currency/v3/state/currency"
 	"github.com/ProtoconNet/mitum2/base"
 )
 

--- a/credential/state.go
+++ b/credential/state.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	extensioncurrency "github.com/ProtoconNet/mitum-currency-extension/v2/currency"
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	currencybase "github.com/ProtoconNet/mitum-currency/v3/base"
+	currency "github.com/ProtoconNet/mitum-currency/v3/state/currency"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
@@ -42,7 +42,7 @@ func NewStateMergeValue(key string, stv base.StateValue) base.StateMergeValue {
 	)
 }
 
-func StateKeyCredentialServicePrefix(ca base.Address, credentialServiceID extensioncurrency.ContractID) string {
+func StateKeyCredentialServicePrefix(ca base.Address, credentialServiceID currencybase.ContractID) string {
 	return fmt.Sprintf("%s%s:%s", CredentialServicePrefix, ca.String(), credentialServiceID)
 }
 
@@ -98,7 +98,7 @@ func IsStateDesignKey(key string) bool {
 	return strings.HasPrefix(key, CredentialServicePrefix) && strings.HasSuffix(key, DesignSuffix)
 }
 
-func StateKeyDesign(ca base.Address, crid extensioncurrency.ContractID) string {
+func StateKeyDesign(ca base.Address, crid currencybase.ContractID) string {
 	return fmt.Sprintf("%s%s", StateKeyCredentialServicePrefix(ca, crid), DesignSuffix)
 }
 
@@ -141,7 +141,7 @@ func (sv TemplateStateValue) HashBytes() []byte {
 	return sv.Template.Bytes()
 }
 
-func StateKeyTemplate(ca base.Address, credentialServiceID extensioncurrency.ContractID, templateID Uint256) string {
+func StateKeyTemplate(ca base.Address, credentialServiceID currencybase.ContractID, templateID Uint256) string {
 	return fmt.Sprintf("%s-%s%s", StateKeyCredentialServicePrefix(ca, credentialServiceID), templateID.String(), TemplateSuffix)
 }
 
@@ -202,7 +202,7 @@ func (sv CredentialStateValue) HashBytes() []byte {
 	return sv.Credential.Bytes()
 }
 
-func StateKeyCredential(ca base.Address, credentialServiceID extensioncurrency.ContractID, templateID Uint256, id string) string {
+func StateKeyCredential(ca base.Address, credentialServiceID currencybase.ContractID, templateID Uint256, id string) string {
 	return fmt.Sprintf("%s-%s-%s%s", StateKeyCredentialServicePrefix(ca, credentialServiceID), templateID.String(), id, CredentialSuffix)
 }
 
@@ -277,7 +277,7 @@ func IsStateHolderDIDKey(key string) bool {
 	return strings.HasPrefix(key, CredentialServicePrefix) && strings.HasSuffix(key, HolderDIDSuffix)
 }
 
-func StateKeyHolderDID(ca base.Address, credentialServiceID extensioncurrency.ContractID, ha base.Address) string {
+func StateKeyHolderDID(ca base.Address, credentialServiceID currencybase.ContractID, ha base.Address) string {
 	return fmt.Sprintf("%s:%s%s", StateKeyCredentialServicePrefix(ca, credentialServiceID), ha.String(), HolderDIDSuffix)
 }
 
@@ -336,22 +336,22 @@ func notExistsState(
 	case found:
 		return nil, base.NewBaseOperationProcessReasonError("%s already exists", name)
 	case !found:
-		st = currency.NewBaseState(base.NilHeight, k, nil, nil, nil)
+		st = currencybase.NewBaseState(base.NilHeight, k, nil, nil, nil)
 	}
 	return st, nil
 }
 
-func existsCurrencyPolicy(cid currency.CurrencyID, getStateFunc base.GetStateFunc) (extensioncurrency.CurrencyPolicy, error) {
-	var policy extensioncurrency.CurrencyPolicy
-	switch i, found, err := getStateFunc(extensioncurrency.StateKeyCurrencyDesign(cid)); {
+func existsCurrencyPolicy(cid currencybase.CurrencyID, getStateFunc base.GetStateFunc) (currencybase.CurrencyPolicy, error) {
+	var policy currencybase.CurrencyPolicy
+	switch i, found, err := getStateFunc(currency.StateKeyCurrencyDesign(cid)); {
 	case err != nil:
-		return extensioncurrency.CurrencyPolicy{}, err
+		return currencybase.CurrencyPolicy{}, err
 	case !found:
-		return extensioncurrency.CurrencyPolicy{}, base.NewBaseOperationProcessReasonError("currency not found, %v", cid)
+		return currencybase.CurrencyPolicy{}, base.NewBaseOperationProcessReasonError("currency not found, %v", cid)
 	default:
-		currencydesign, ok := i.Value().(extensioncurrency.CurrencyDesignStateValue) //nolint:forcetypeassert //...
+		currencydesign, ok := i.Value().(currency.CurrencyDesignStateValue) //nolint:forcetypeassert //...
 		if !ok {
-			return extensioncurrency.CurrencyPolicy{}, errors.Errorf("expected CurrencyDesignStateValue, not %T", i.Value())
+			return currencybase.CurrencyPolicy{}, errors.Errorf("expected CurrencyDesignStateValue, not %T", i.Value())
 		}
 		policy = currencydesign.CurrencyDesign.Policy()
 	}

--- a/credential/state_bson.go
+++ b/credential/state_bson.go
@@ -1,7 +1,7 @@
 package credential
 
 import (
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 	"go.mongodb.org/mongo-driver/bson"

--- a/credential/template.go
+++ b/credential/template.go
@@ -86,7 +86,7 @@ func (t Template) IsValid([]byte) error {
 		return err
 	}
 
-	if expire.Compare(service) <= 0 {
+	if expire.UnixNano() < service.UnixNano() {
 		return util.ErrInvalid.Errorf("expire date <= service date, %s <= %s", t.expirationDate, t.serviceDate)
 	}
 

--- a/credential/template_bson.go
+++ b/credential/template_bson.go
@@ -3,7 +3,7 @@ package credential
 import (
 	"go.mongodb.org/mongo-driver/bson"
 
-	bsonenc "github.com/ProtoconNet/mitum-currency/v2/digest/util/bson"
+	bsonenc "github.com/ProtoconNet/mitum-currency/v3/digest/util/bson"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/ProtoconNet/mitum2/util/hint"
 )

--- a/credential/types.go
+++ b/credential/types.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/ProtoconNet/mitum-currency/v2/currency"
+	"github.com/ProtoconNet/mitum-currency/v3/base"
 	"github.com/ProtoconNet/mitum2/util"
 	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
@@ -15,7 +15,7 @@ type Uint256 struct {
 }
 
 func NewUint256FromString(s string) (Uint256, error) {
-	b, err := currency.NewBigFromString(s)
+	b, err := base.NewBigFromString(s)
 	if err != nil {
 		return Uint256{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/ProtoconNet/mitum-credential
 go 1.19
 
 require (
-	github.com/ProtoconNet/mitum-currency-extension/v2 v2.0.0-20230509022445-e3cefd28984e
-	github.com/ProtoconNet/mitum-currency/v2 v2.0.0-20230508143724-e411584507ab
-	github.com/ProtoconNet/mitum2 v0.0.0-20230327234451-801228e1e81f
+	github.com/ProtoconNet/mitum-currency/v3 v3.0.0-alpha.0.20230607080741-621c42429cfd
+	github.com/ProtoconNet/mitum2 v0.0.2-alpha
 	github.com/alecthomas/kong v0.7.1
 	github.com/arl/statsviz v0.5.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,10 @@
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
-github.com/ProtoconNet/mitum-currency-extension/v2 v2.0.0-20230509022445-e3cefd28984e h1:5JQ3W7S2cVTCpncA+uIU+k8XQy/4cTw54uo8MVqB8kw=
-github.com/ProtoconNet/mitum-currency-extension/v2 v2.0.0-20230509022445-e3cefd28984e/go.mod h1:iPcH1d3LHcbR9fVtocrEiggR+mvQvmpSVE5zM2Qjuew=
-github.com/ProtoconNet/mitum-currency/v2 v2.0.0-20230508143724-e411584507ab h1:0m7uaJSJn5B9YZ8n9f6eqen11feVTIIIdswFRVeVfUA=
-github.com/ProtoconNet/mitum-currency/v2 v2.0.0-20230508143724-e411584507ab/go.mod h1:ulDIYC1qDUcARt02XrB5FYpbEOu5ZdNGWV9z/fRMezA=
-github.com/ProtoconNet/mitum2 v0.0.0-20230327234451-801228e1e81f h1:2rRjpD8oPq3AdIJ5VWTANv09SHUSTJGoH09YVh9Br48=
-github.com/ProtoconNet/mitum2 v0.0.0-20230327234451-801228e1e81f/go.mod h1:gjY90ADYXWm4hw2kcso/3vKhT1NvzH1iKCqLTwmtU+I=
+github.com/ProtoconNet/mitum-currency/v3 v3.0.0-alpha.0.20230607080741-621c42429cfd h1:phRcsAtg3A2XRDRDgmk77Dpw9WSfrlSztnlamEumk2M=
+github.com/ProtoconNet/mitum-currency/v3 v3.0.0-alpha.0.20230607080741-621c42429cfd/go.mod h1:BTa7+EQQoJK6b31T+fYht7GifMSXhh3XpIVxQL7+kQY=
+github.com/ProtoconNet/mitum2 v0.0.2-alpha h1:xSBP0TctUgSLyoMri1kTmUr2D0CmZ3ubpJ4iFfOqD6c=
+github.com/ProtoconNet/mitum2 v0.0.2-alpha/go.mod h1:hBs6S3Neb0fFPPRzmNKHHAN0WMYrTPbZaBL5H3XKet0=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/ProtoconNet/mitum-credential/cmds"
-	currencycmds "github.com/ProtoconNet/mitum-currency/v2/cmds"
+	currencycmds "github.com/ProtoconNet/mitum-currency/v3/cmds"
 	"github.com/ProtoconNet/mitum2/base"
 	"github.com/ProtoconNet/mitum2/launch"
 	"github.com/ProtoconNet/mitum2/util"


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- chore

### Current Behavior (Link to an open issue)

- go.mod has the old module path of mitum2 and mitum-currency

### New Behavior (if this is a feature change)

- go.mod updated
- Use `time.Time.UnixNano` to compare expire and service date
