### PR TITLE
fix: credential digest

### DIFF
--- a/digest/block_session_did_handler.go
+++ b/digest/block_session_did_handler.go
@@ -32,6 +32,7 @@ func (bs *BlockSession) prepareDID() error {
 				return err
 			}
 			bs.credentialMap[cre.ID()] = struct{}{}
+			bs.templateMap[cre.TemplateID()] = struct{}{}
 			didCredentialModels = append(didCredentialModels, j...)
 
 		case state.IsStateHolderDIDKey(st.Key()):


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- When deleting duplicate credential information, only cases with the same template ID and credential ID are deleted.

- Should fix CleanByHeightColName function of database.go of mitum-currency v3.

### Current Behavior (Link to an open issue)

-
-

### New Behavior (if this is a feature change)

-
-

### Other information

-
-
